### PR TITLE
change unused-vars to warn instead of error

### DIFF
--- a/packages/eslint-config-imperium/index.js
+++ b/packages/eslint-config-imperium/index.js
@@ -39,12 +39,12 @@ module.exports = {
 		'no-return-assign': ['error', 'except-parens'],
 		'no-console': ['error'],
 		'no-plusplus': 'off',
-		'no-unused-vars': ['error', {varsIgnorePattern: 'd'}],
+		'no-unused-vars': ['warn', {varsIgnorePattern: 'd'}],
 		'lines-between-class-members': ['error', 'always', {exceptAfterSingleLine: true}],
 
 		// Typescript
 		'@typescript-eslint/indent': ['off'],
-		'@typescript-eslint/no-unused-vars': ['error', {varsIgnorePattern: 'd'}],
+		'@typescript-eslint/no-unused-vars': ['warn', {varsIgnorePattern: 'd'}],
 		'@typescript-eslint/no-unused-expressions': ['off'], // This was disabled because some upgrade to airbnb rules.
 		'@typescript-eslint/explicit-member-accessibility': ['off'],
 		'@typescript-eslint/explicit-function-return-type': [

--- a/packages/eslint-config-imperium/tests/__snapshots__/index.test.js.snap
+++ b/packages/eslint-config-imperium/tests/__snapshots__/index.test.js.snap
@@ -56,7 +56,7 @@ Object {
       "off",
     ],
     "@typescript-eslint/no-unused-vars": Array [
-      "error",
+      "warn",
       Object {
         "varsIgnorePattern": "d",
       },
@@ -95,7 +95,7 @@ Object {
       },
     ],
     "no-unused-vars": Array [
-      "error",
+      "warn",
       Object {
         "varsIgnorePattern": "d",
       },


### PR DESCRIPTION
this allows for declaring parameters for methods that may change in the future.